### PR TITLE
fix: filter out annotation classes when scanning for annotaded classes

### DIFF
--- a/plugin/src/main/kotlin/cloud/rio/gdprdoc/GenerateGdprDocumentationTask.kt
+++ b/plugin/src/main/kotlin/cloud/rio/gdprdoc/GenerateGdprDocumentationTask.kt
@@ -85,7 +85,9 @@ abstract class GenerateGdprDocumentationTask : DefaultTask() {
             .overrideClassLoaders(scanClassLoader)
             .scan()
 
-        scanResult.getClassesWithAnnotation(GdprData::class.java.canonicalName).forEach { classInfo ->
+        scanResult.getClassesWithAnnotation(GdprData::class.java.canonicalName)
+            .filterNot { it.name.startsWith("cloud.rio.gdprdoc.annotations") }
+            .forEach { classInfo ->
             try {
                 logger.debug("Processing class: ${classInfo.name}")
                 val (newItems, newlinks) = processClass(classInfo)


### PR DESCRIPTION
Prevents scanning the annotation classes themselves and gets rid of unnecessary warnings like `No annotation found for class cloud.rio.gdprdoc.annotations.GdprData$Incoming other than the @GdprData marker`